### PR TITLE
README updated

### DIFF
--- a/Maven-installation/READme.md
+++ b/Maven-installation/READme.md
@@ -37,8 +37,8 @@ sudo mv apache-maven-3.8.5/ maven
 ## .#Step3) Set Environmental Variable  - For Specific User eg ec2-user
 ``` sh
 vi ~/.bash_profile  # and add the lines below
-export M2_HOME=/opt/maven
-export PATH=$PATH:$M2_HOME/bin
+export PATH=$PATH:opt/maven/bin
+export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk
 ```
 ## .#Step4) Refresh the profile file and Verify if maven is running
 ```sh


### PR DESCRIPTION
1. Removed the environment variable M2_HOME from step 3 and appended the full  maven/bin directory to PATH variable. Per Maven 3.5 release note, M2_HOME is no longer supported, see link to release note, https://maven.apache.org/docs/3.5.0/release-notes.html
2. Set JAVA-HOME environment variable, per release note, it is a requirement.