### PR TITLE
change tomcat version from 9.0.75 to 9.0.76

### DIFF
--- a/Tomcat-installation/READme.md
+++ b/Tomcat-installation/READme.md
@@ -24,14 +24,14 @@ sudo yum install java-1.8.0-openjdk-devel -y
 # install wget unzip packages.
 sudo yum install wget unzip -y
 ```
-## Install Tomcat version 9.0.75
+## Install Tomcat version 9.0.76
 ### Download and extract the tomcat server
 ``` sh
-sudo wget  https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.75/bin/apache-tomcat-9.0.75.zip
-sudo unzip apache-tomcat-9.0.75.zip
-sudo rm -rf apache-tomcat-9.0.75.zip
+sudo wget https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.76/bin/apache-tomcat-9.0.76.zip
+sudo unzip apache-tomcat-9.0.76.zip
+sudo rm -rf apache-tomcat-9.0.76.zip
 ### rename tomcat for good naming convention
-sudo mv apache-tomcat-9.0.75 tomcat9  
+sudo mv apache-tomcat-9.0.76 tomcat9  
 ### assign executable permissions to the tomcat home directory
 sudo chmod 777 -R /opt/tomcat9
 sudo chown ec2-user -R /opt/tomcat9


### PR DESCRIPTION
 Attempt to download 9.0.75 results in Error 404 not found. 
The latest/stable version of Apache Tomcat 9 is 9.0.76 (released on June 5, 2023) and this worked without issues with Java jdk 1.8+